### PR TITLE
Switch to pdfminer.six, since it's actually maintained.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'License :: OSI Approved :: MIT License',
     ],
     keywords='pdf pdfminer extract mining images',
-    install_requires=['pdfminer3k', 'six'],
+    install_requires=['pdfminer.six', 'six'],
     extras_require={
         'PIL': ['Pillow'],
     },


### PR DESCRIPTION
A bunch of misc image parsing stuff.

Basically, I needed to parse some files with a bunch of oddball images, so I wound up having to switch to `pdfminer.six`, since it seems to be actively maintained, and fixed a colorspace issue I was having.

I've also implemented handling for embedded ICC profiles in certain contexts. There's more image stuff I'm working on now. 

Note that this may have made a bunch of stuff in parts of minecart I haven't touched explode. Apparently `pdfminer.six` has been fairly aggressively improving their internal code structure, and it's lead to follow-on effects in minecart. I've fixed the ones I've hit so far, but it's likely not all of them.