### PR TITLE
Use pdfminer (pdfminer3k is no longer available on pip)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ README = path.join(path.dirname(path.abspath(__file__)), "README.rst")
 
 setup(
     name="minecart",
-    version="0.3.0",
+    version="0.3.1",
     description=("Simple, Pythonic extraction of images, text, and shapes "
                  "from PDFs"),
     long_description=open(README).read(),
@@ -24,7 +24,7 @@ setup(
         'License :: OSI Approved :: MIT License',
     ],
     keywords='pdf pdfminer extract mining images',
-    install_requires=['pdfminer3k', 'six'],
+    install_requires=['pdfminer>=20191010', 'six'],
     extras_require={
         'PIL': ['Pillow'],
     },


### PR DESCRIPTION
@felipeochoa it appears that `pdfminer3k` has been removed from `pip` https://pypi.org/project/pdfminer3k/ . Consequently, `pip install minecart` no longer works:
```
> pip install minecart
Collecting minecart
  Using cached minecart-0.3.0-py3-none-any.whl (23 kB)
Requirement already satisfied: six in /usr/local/share/c3/conda/envs/mc4/lib/python3.8/site-packages (from minecart) (1.14.0)
ERROR: Could not find a version that satisfies the requirement pdfminer3k (from minecart) (from versions: none)
ERROR: No matching distribution found for pdfminer3k (from minecart)
```
Note that `pdfminer` >=20191010 supports python 3 only https://pypi.org/project/pdfminer/ 
